### PR TITLE
Runge-Kutta Simulator, PD control in linear region, Visualizer

### DIFF
--- a/ROS/underactuated_ws/src/pendulum/CMakeLists.txt
+++ b/ROS/underactuated_ws/src/pendulum/CMakeLists.txt
@@ -21,3 +21,6 @@ target_link_libraries(controller ${catkin_LIBRARIES})
 
 add_executable(sim nodes/sim/simulator.cpp)
 target_link_libraries(sim ${catkin_LIBRARIES})
+
+add_executable(sim_rk4 nodes/sim/simulator_rk4.cpp)
+target_link_libraries(sim_rk4 ${catkin_LIBRARIES})

--- a/ROS/underactuated_ws/src/pendulum/CMakeLists.txt
+++ b/ROS/underactuated_ws/src/pendulum/CMakeLists.txt
@@ -24,3 +24,7 @@ target_link_libraries(sim ${catkin_LIBRARIES})
 
 add_executable(sim_rk4 nodes/sim/simulator_rk4.cpp)
 target_link_libraries(sim_rk4 ${catkin_LIBRARIES})
+
+catkin_install_python(PROGRAMS nodes/sim/pendulum_viz.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/ROS/underactuated_ws/src/pendulum/nodes/controller/controller.cpp
+++ b/ROS/underactuated_ws/src/pendulum/nodes/controller/controller.cpp
@@ -10,12 +10,12 @@ struct Pendulum
 {
     struct Params
     {
-        double l1 = 1; // Bar lengths
-        double m1 = 1; // Bar masses
-        double b1 = 0; // Friction at the joints
-        double I1 = 1; // Inertia tensors
-        double MaxQ = 1; // Torque limit. 0 means unlimited torque
-        double MaxPower = 0; // Power limit. 0 means unlimited power
+        double l1 = 1.0; // Bar lengths
+        double m1 = 1.0; // Bar masses
+        double b1 = 0.0; // Friction at the joints
+        double I1 = 1.0; // Inertia tensors
+        double MaxQ = 1.0; // Torque limit. 0 means unlimited torque
+        double MaxPower = 0.0; // Power limit. 0 means unlimited power
 
         void refreshInertia()
         {
@@ -39,7 +39,7 @@ struct Pendulum
 struct EnergyPumpController : public Pendulum::Controller
 {
     static constexpr auto g = 9.81;
-    double energyGain = 1;
+    double energyGain = 1.0;
     double ePrevPD = 0.0;
 
     double control(const Pendulum::State& x, const Pendulum::Params& p, const double controlHz=100.0) override

--- a/ROS/underactuated_ws/src/pendulum/nodes/controller/controller.cpp
+++ b/ROS/underactuated_ws/src/pendulum/nodes/controller/controller.cpp
@@ -42,7 +42,7 @@ struct EnergyPumpController : public Pendulum::Controller
     double energyGain = 1.0;
     double ePrevPD = 0.0;
 
-    double control(const Pendulum::State& x, const Pendulum::Params& p, const double controlHz=100.0) override
+    double control(const Pendulum::State& x, const Pendulum::Params& p, double controlHz=100.0) override
     {
         // Target energy to stay still at the top:
         auto mgl = p.m1 * g * p.l1;

--- a/ROS/underactuated_ws/src/pendulum/nodes/controller/controller.cpp
+++ b/ROS/underactuated_ws/src/pendulum/nodes/controller/controller.cpp
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <mutex>
 
+constexpr double PI = 3.14159265358979323;
+
 struct Pendulum
 {
     struct Params
@@ -12,7 +14,7 @@ struct Pendulum
         double m1 = 1; // Bar masses
         double b1 = 0; // Friction at the joints
         double I1 = 1; // Inertia tensors
-        double MaxQ = 0; // Torque limit. 0 means unlimited torque
+        double MaxQ = 1; // Torque limit. 0 means unlimited torque
         double MaxPower = 0; // Power limit. 0 means unlimited power
 
         void refreshInertia()
@@ -30,7 +32,7 @@ struct Pendulum
 
     struct Controller
     {
-        virtual double control(const State& x, const Params& p) = 0;
+        virtual double control(const State& x, const Params& p, const double controlHz) = 0;
     };
 };
 
@@ -38,8 +40,9 @@ struct EnergyPumpController : public Pendulum::Controller
 {
     static constexpr auto g = 9.81;
     double energyGain = 1;
+    double ePrevPD = 0.0;
 
-    double control(const Pendulum::State& x, const Pendulum::Params& p) override
+    double control(const Pendulum::State& x, const Pendulum::Params& p, const double controlHz=100.0) override
     {
         // Target energy to stay still at the top:
         auto mgl = p.m1 * g * p.l1;
@@ -49,6 +52,11 @@ struct EnergyPumpController : public Pendulum::Controller
         auto T = 0.5 * p.m1 * p.l1 * p.l1 * x.dTheta * x.dTheta;
         auto V = p.m1 * g * p.l1 * -std::cos(x.theta);
         auto E = T + V;
+
+        // PD Controller params
+        constexpr auto linearRegion = 5.0*PI/180.0; // +- 5 deg at the top is linear enough.
+        double Kp      = 15.0;
+        double Kd      = 1.5;
 
         // Choose control method
         bool pumpEnergy = false;
@@ -61,7 +69,8 @@ struct EnergyPumpController : public Pendulum::Controller
                 pumpEnergy = true;
         }
 
-        if (pumpEnergy)
+
+        if (pumpEnergy && std::abs(x.theta-PI) > linearRegion)
         {
             auto dE = Egoal - E;
 
@@ -72,6 +81,18 @@ struct EnergyPumpController : public Pendulum::Controller
             if(p.MaxQ > 0)
                 U = std::min(p.MaxQ, std::max(-p.MaxQ, Ugoal));
             return U;
+        }
+        else if (std::abs(x.theta-PI) < linearRegion)
+        {
+            // PD Controller
+            const auto e     = PI-x.theta;
+            const auto dT = 1/controlHz;
+            const auto e_dot = (e-ePrevPD)/dT;
+            auto U = Kp*e + Kd*e_dot;
+
+            ePrevPD = e;
+
+            return std::min(p.MaxQ, std::max(-p.MaxQ, U));
         }
         else
         {
@@ -101,13 +122,16 @@ int main(int argc, char **argv)
     ros::Subscriber controller_sub = n.subscribe<gazebo_msgs::ModelState>("pendulum_x", 1, 
         [&](const gazebo_msgs::ModelState::ConstPtr& pendulum_x) {
             const std::lock_guard<std::mutex> lock(p.state_mutex);
-            p.state.theta =  2.0*std::acos(pendulum_x->pose.orientation.w);
+            // Uncomment the math below to treat theta as a quaternion. Currently just using w == theta
+            // p.state.theta = 2.0*std::acos(pendulum_x->pose.orientation.w);
+            p.state.theta =  pendulum_x->pose.orientation.w;
             p.state.dTheta = pendulum_x->twist.angular.z;
             // lock_guard mutex released when it goes out of scope
         }
     );
 
-    ros::Rate loop_rate(100);
+    const auto controlHz = 100.0;
+    ros::Rate loop_rate(controlHz);
     
     geometry_msgs::Wrench control_u;
     Pendulum::State localState;
@@ -119,7 +143,7 @@ int main(int argc, char **argv)
             localState = p.state;
         }
 
-        auto u = p.controller.control(localState, p.params);
+        auto u = p.controller.control(localState, p.params, controlHz);
 
         control_u.torque.z = u;
         controller_pub.publish(control_u);

--- a/ROS/underactuated_ws/src/pendulum/nodes/sim/pendulum_viz.py
+++ b/ROS/underactuated_ws/src/pendulum/nodes/sim/pendulum_viz.py
@@ -5,28 +5,86 @@ import rospy
 import math
 from geometry_msgs.msg import *
 from gazebo_msgs.msg import ModelState
+import numpy as np
 
-pendulum_length = 1
+class Pendulum:
+    l1 = 1
+    m1 = 1
 
-ax = plt.subplot(111, polar=True)
+    g = 9.18
 
-def callback(data):
-    # Uncomment the math below to treat theta as a quaternion. Currently just using w == theta 
-    # x,y,z,w = data.pose.orientation.x, data.pose.orientation.y, data.pose.orientation.z, data.pose.orientation.w
-    # theta = 2.0*math.atan2(math.sqrt(x*x + y*y + z*z), w)
-    theta = data.pose.orientation.w
-    theta, r = [theta]*2, [0,pendulum_length]
+class VizConsole:
+    fig = plt.figure()
+    ax0 = fig.add_subplot(211, polar=True)
+    ax1 = fig.add_subplot(212)
 
-    ax.cla()
-    ax.set_theta_zero_location("S")
-    ax.set_yticklabels([])
-    ax.set_rmax(pendulum_length+1)
+    pendulum = Pendulum()
 
-    ax.plot(theta, r, color='blue', lw=2)
-    plt.pause(0.00001)
+    count = 0
+
+    def __init__(self, plot_E_every_n = 1, history_sec=1, data_rate_Hz=100):
+        self.plot_E_every_n = plot_E_every_n
+        self.data_rate_Hz = data_rate_Hz
+        self.history_sec = history_sec
+        self.history_len = history_sec*data_rate_Hz//plot_E_every_n
+
+        self.time_ticks = np.linspace(0, 1, self.history_len)
+        self.E_history = [0]*self.history_len
+        self.T_history = [0]*self.history_len
+        self.V_history = [0]*self.history_len
+
+
+    def viz_pendulum(self, data):
+        # Uncomment the math below to treat theta as a quaternion. Currently just using w == theta 
+        # x,y,z,w = data.pose.orientation.x, data.pose.orientation.y, data.pose.orientation.z, data.pose.orientation.w
+        # theta = 2.0*math.atan2(math.sqrt(x*x + y*y + z*z), w)
+        theta = data.pose.orientation.w
+        theta, r = [theta]*2, [0,self.pendulum.l1]
+
+        self.ax0.cla()
+        self.ax0.set_theta_zero_location("S")
+        self.ax0.set_yticklabels([])
+        self.ax0.set_rmax(self.pendulum.l1+1)
+
+        self.ax0.plot(theta, r, color='darkorange', lw=3)
+
+    def viz_energy(self, data):
+        if self.count % self.plot_E_every_n != 0:
+            return
+
+        theta = data.pose.orientation.w
+        dTheta = data.twist.angular.z
+
+        T = 0.5 * self.pendulum.m1 * self.pendulum.l1 * self.pendulum.l1 * dTheta * dTheta
+        V = self.pendulum.m1 * self.pendulum.g * self.pendulum.l1 * -math.cos(theta) + self.pendulum.m1 * self.pendulum.g * self.pendulum.l1
+        E = T + V
+
+        self.E_history = self.E_history[1:] + [E]
+        self.T_history = self.T_history[1:] + [T]
+        self.V_history = self.V_history[1:] + [V]
+
+        self.ax1.cla()
+        # self.ax1.set_ylim([0,10])
+        self.ax1.plot(self.time_ticks, self.E_history, label='E', color='royalblue')
+        self.ax1.plot(self.time_ticks, self.T_history, label='T', color='dodgerblue', alpha=0.6)
+        self.ax1.plot(self.time_ticks, self.V_history, label='V', color='indigo', alpha=0.6)
+        self.ax1.legend()
+    
+    def draw(self):
+        plt.pause(0.00001)
+
+    def callback(self, data):
+        viz.viz_pendulum(data)
+        viz.viz_energy(data)
+        viz.draw()
+
+        self.count += 1
+    
+
+viz = VizConsole()
 
 rospy.init_node('pendulum_viz', anonymous=True)
-rospy.Subscriber("pendulum_x", ModelState, callback, queue_size=1)
+rospy.Subscriber("pendulum_x", ModelState, viz.callback, queue_size=1)
 
 plt.show(block=True)
 rospy.spin()

--- a/ROS/underactuated_ws/src/pendulum/nodes/sim/pendulum_viz.py
+++ b/ROS/underactuated_ws/src/pendulum/nodes/sim/pendulum_viz.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import matplotlib.pyplot as plt
+import rospy
+import math
+from geometry_msgs.msg import *
+from gazebo_msgs.msg import ModelState
+
+pendulum_length = 1
+
+ax = plt.subplot(111, polar=True)
+
+def callback(data):
+    # Uncomment the math below to treat theta as a quaternion. Currently just using w == theta 
+    # x,y,z,w = data.pose.orientation.x, data.pose.orientation.y, data.pose.orientation.z, data.pose.orientation.w
+    # theta = 2.0*math.atan2(math.sqrt(x*x + y*y + z*z), w)
+    theta = data.pose.orientation.w
+    theta, r = [theta]*2, [0,pendulum_length]
+
+    ax.cla()
+    ax.set_theta_zero_location("S")
+    ax.set_yticklabels([])
+    ax.set_rmax(pendulum_length+1)
+
+    ax.plot(theta, r, color='blue', lw=2)
+    plt.pause(0.00001)
+
+rospy.init_node('pendulum_viz', anonymous=True)
+rospy.Subscriber("pendulum_x", ModelState, callback, queue_size=1)
+
+plt.show(block=True)
+rospy.spin()

--- a/ROS/underactuated_ws/src/pendulum/nodes/sim/simulator_rk4.cpp
+++ b/ROS/underactuated_ws/src/pendulum/nodes/sim/simulator_rk4.cpp
@@ -1,45 +1,14 @@
-// Stand in pendulum simulator
+// 4th Order Runge-Kutta based pendulum simulator
 
 #include "ros/ros.h"
 #include "geometry_msgs/Wrench.h"
 #include "gazebo_msgs/ModelState.h"
 #include <cmath>
 #include <mutex>
+#include <cstdlib>
+#include <ctime>
 
 constexpr double PI = 3.14159265358979323;
-
-static int squirrelNoise(int position, int seed = 0)
-{
-    constexpr unsigned int BIT_NOISE1 = 0xB5297A4D;
-    constexpr unsigned int BIT_NOISE2 = 0x68E31DA4;
-    constexpr unsigned int BIT_NOISE3 = 0x1B56C4E9;
-
-    int mangled = position;
-    mangled *= BIT_NOISE1;
-    mangled += seed;
-    mangled ^= (mangled >> 8);
-    mangled *= BIT_NOISE2;
-    mangled ^= (mangled << 8);
-    mangled *= BIT_NOISE3;
-    mangled ^= (mangled >> 8);
-    return mangled;
-}
-
-struct squirrelRng
-{
-    int rand()
-    {
-        return squirrelNoise(state++);
-    }
-
-    float uniform()
-    {
-        auto i = rand();
-        return float(i & ((1 << 24) - 1)) / (1 << 24);
-    }
-
-    int state = 0;
-};
 
 struct Pendulum
 {
@@ -47,23 +16,7 @@ struct Pendulum
     {
         double l1 = 1; // Bar lengths
         double m1 = 1; // Bar masses
-        // double b1 = 0; // Friction at the joints
-        // double MaxQ = 0; // Torque limit. 0 means unlimited torque
-        // double MaxPower = 0; // Power limit. 0 means unlimited power
-
-        // void refreshInertia()
-        // {
-        //     // Inertia concentrated at the end
-        //     I1 = m1 * l1 * l1 / 3;
-        // }
-        
-        void randomize(squirrelRng& rng)
-        {
-            l1 = rng.uniform() * 10;
-            m1 = rng.uniform() * 10;
-            // b1 = rng.uniform() * 10;
-            // refreshInertia();
-        }
+        double b1 = 0; // Friction at the joints
     } m_params;
 
     struct State
@@ -73,15 +26,6 @@ struct Pendulum
         double theta = 0;
         double dTheta = 0;
 
-        void perturbate(squirrelRng& rng)
-        {
-            dTheta += rng.uniform() - 0.5;
-        }
-        
-        void randomize(squirrelRng& rng)
-        {
-            theta = rng.uniform() * 2 * 3.1415927;
-        }
         State operator* (double val) const
         {
             return State(val*theta, val*dTheta);
@@ -98,23 +42,22 @@ struct Pendulum
     {
         State nextState;
         nextState.theta  = state.dTheta;
-        nextState.dTheta = -g/m_params.l1 * std::sin(state.theta) + u/(m_params.m1*m_params.l1*m_params.l1);
+        nextState.dTheta = -g/m_params.l1 * std::sin(state.theta) + 
+                           (u+m_params.b1*state.dTheta)/(m_params.m1*m_params.l1*m_params.l1);
         return nextState;
     }
     void stepSimulation(double stepDt, double u)
     {
+        ROS_INFO("U: %f", u);
         const auto k1 = f(m_state, u);
         const auto k2 = f(m_state + (k1*(stepDt/2.0)), u);
         const auto k3 = f(m_state + (k2*(stepDt/2.0)), u);
         const auto k4 = f(m_state + k3*stepDt, u);
 
         m_state = m_state + (k1 + k2*2.0 + k3*2.0 + k4) * (stepDt/6.0);
-        m_state.theta = std::fmod(m_state.theta, 2.0*PI);
+        m_state.theta = std::fmod(m_state.theta+2.0*PI, 2.0*PI);
     }
 };
-
-using StateMsg = gazebo_msgs::ModelState;
-using PoseMsg = geometry_msgs::Pose;
 
 int main(int argc, char **argv)
 {
@@ -124,7 +67,7 @@ int main(int argc, char **argv)
 
     // Set up ROS topics for this node
     constexpr auto cQueueSize = 1;
-    auto statePublisher = nodeHandle.advertise<StateMsg>("pendulum_x", cQueueSize);
+    auto statePublisher = nodeHandle.advertise<gazebo_msgs::ModelState>("pendulum_x", cQueueSize);
 
     std::atomic<double> torque{};
     auto subscriber = nodeHandle.subscribe<geometry_msgs::Wrench>("control_u", 1,
@@ -134,33 +77,29 @@ int main(int argc, char **argv)
     );
 
     // Initialize a pendulum
-    squirrelRng rng;
-    rng.rand(); // Seed random number generator
+    srand((unsigned) time(0)); // seed the random number generator
     Pendulum pendulum;
-    // pendulum.m_params.randomize(rng);
-    // pendulum.m_state.randomize(rng);
-    pendulum.m_state.theta = PI/2.0;
+    pendulum.m_state.theta = (rand()%100)*2*PI;
+    pendulum.m_state.dTheta = (rand()%100)*0.05;
     
     // Set up simulation loop
     constexpr int updateRate = 100; // Hertz
     constexpr double stepDt = 1.0 / updateRate;
-    ros::Rate loopRate(100);
+    ros::Rate loopRate(updateRate);
     int i = 0;
     while(ros::ok())
     {
-        // Random perturbations
-        // if(++i >= 300)
-        // {
-        //     i = 0;
-        //     pendulum.m_state.perturbate(rng);
-        // }
         // Simulate
-        const auto u = 0.0;
-        pendulum.stepSimulation(stepDt, torque);
+        pendulum.stepSimulation(stepDt, torque.load());
 
         // Publish state
-        StateMsg stateUpdate;
-        stateUpdate.pose.orientation.w = pendulum.m_state.theta;
+        gazebo_msgs::ModelState stateUpdate;
+
+        // Uncomment the math below to treat theta as a quaternion. Currently just using w == theta
+        // stateUpdate.pose.orientation.x = 0.0;
+        // stateUpdate.pose.orientation.y = 0.0;
+        // stateUpdate.pose.orientation.z = 1.0;
+        stateUpdate.pose.orientation.w = pendulum.m_state.theta;//std::cos(pendulum.m_state.theta/2.0);
         stateUpdate.twist.angular.z = pendulum.m_state.dTheta;
         statePublisher.publish(stateUpdate);
 

--- a/ROS/underactuated_ws/src/pendulum/nodes/sim/simulator_rk4.cpp
+++ b/ROS/underactuated_ws/src/pendulum/nodes/sim/simulator_rk4.cpp
@@ -16,7 +16,7 @@ struct Pendulum
     {
         double l1 = 1; // Bar lengths
         double m1 = 1; // Bar masses
-        double b1 = 0; // Friction at the joints
+        double b1 = 0.0; // Friction at the joints
     } m_params;
 
     struct State
@@ -48,7 +48,11 @@ struct Pendulum
     }
     void stepSimulation(double stepDt, double u)
     {
-        ROS_INFO("U: %f", u);
+        const auto T = 0.5 * m_params.m1 * m_params.l1 * m_params.l1 * m_state.dTheta * m_state.dTheta;
+        const auto V = m_params.m1 * g * m_params.l1 * -std::cos(m_state.theta) + m_params.m1 * g * m_params.l1;
+        const auto E = T + V;
+
+        ROS_INFO("E: %f, U: %f", E, u);
         const auto k1 = f(m_state, u);
         const auto k2 = f(m_state + (k1*(stepDt/2.0)), u);
         const auto k3 = f(m_state + (k2*(stepDt/2.0)), u);

--- a/ROS/underactuated_ws/src/pendulum/nodes/sim/simulator_rk4.cpp
+++ b/ROS/underactuated_ws/src/pendulum/nodes/sim/simulator_rk4.cpp
@@ -43,7 +43,7 @@ struct Pendulum
         State nextState;
         nextState.theta  = state.dTheta;
         nextState.dTheta = -g/m_params.l1 * std::sin(state.theta) + 
-                           (u+m_params.b1*state.dTheta)/(m_params.m1*m_params.l1*m_params.l1);
+                           (u-m_params.b1*state.dTheta)/(m_params.m1*m_params.l1*m_params.l1);
         return nextState;
     }
     void stepSimulation(double stepDt, double u)

--- a/ROS/underactuated_ws/src/pendulum/nodes/sim/simulator_rk4.cpp
+++ b/ROS/underactuated_ws/src/pendulum/nodes/sim/simulator_rk4.cpp
@@ -1,0 +1,164 @@
+// Stand in pendulum simulator
+
+#include "ros/ros.h"
+#include "geometry_msgs/Wrench.h"
+#include "gazebo_msgs/ModelState.h"
+#include <cmath>
+#include <mutex>
+
+constexpr double PI = 3.14159265358979323;
+
+static int squirrelNoise(int position, int seed = 0)
+{
+    constexpr unsigned int BIT_NOISE1 = 0xB5297A4D;
+    constexpr unsigned int BIT_NOISE2 = 0x68E31DA4;
+    constexpr unsigned int BIT_NOISE3 = 0x1B56C4E9;
+
+    int mangled = position;
+    mangled *= BIT_NOISE1;
+    mangled += seed;
+    mangled ^= (mangled >> 8);
+    mangled *= BIT_NOISE2;
+    mangled ^= (mangled << 8);
+    mangled *= BIT_NOISE3;
+    mangled ^= (mangled >> 8);
+    return mangled;
+}
+
+struct squirrelRng
+{
+    int rand()
+    {
+        return squirrelNoise(state++);
+    }
+
+    float uniform()
+    {
+        auto i = rand();
+        return float(i & ((1 << 24) - 1)) / (1 << 24);
+    }
+
+    int state = 0;
+};
+
+struct Pendulum
+{
+    struct Params
+    {
+        double l1 = 1; // Bar lengths
+        double m1 = 1; // Bar masses
+        // double b1 = 0; // Friction at the joints
+        // double MaxQ = 0; // Torque limit. 0 means unlimited torque
+        // double MaxPower = 0; // Power limit. 0 means unlimited power
+
+        // void refreshInertia()
+        // {
+        //     // Inertia concentrated at the end
+        //     I1 = m1 * l1 * l1 / 3;
+        // }
+        
+        void randomize(squirrelRng& rng)
+        {
+            l1 = rng.uniform() * 10;
+            m1 = rng.uniform() * 10;
+            // b1 = rng.uniform() * 10;
+            // refreshInertia();
+        }
+    } m_params;
+
+    struct State
+    {
+        State() : theta(0.0), dTheta(0.0) {}
+        State(const double theta, const double dTheta) : theta(theta), dTheta(dTheta) {}
+        double theta = 0;
+        double dTheta = 0;
+
+        void perturbate(squirrelRng& rng)
+        {
+            dTheta += rng.uniform() - 0.5;
+        }
+        
+        void randomize(squirrelRng& rng)
+        {
+            theta = rng.uniform() * 2 * 3.1415927;
+        }
+        State operator* (double val) const
+        {
+            return State(val*theta, val*dTheta);
+        }
+        State operator+ (const State& rhs) const
+        {
+            return State(theta + rhs.theta, dTheta + rhs.dTheta);
+        }
+    } m_state;
+    
+    static constexpr auto g = 9.81;
+
+    State f(const State state, const double u)
+    {
+        State nextState;
+        nextState.theta  = state.dTheta;
+        nextState.dTheta = -g/m_params.l1 * std::sin(state.theta) + u/(m_params.m1*m_params.l1*m_params.l1);
+        return nextState;
+    }
+    void stepSimulation(double stepDt, double u)
+    {
+        const auto k1 = f(m_state, u);
+        const auto k2 = f(m_state + (k1*(stepDt/2.0)), u);
+        const auto k3 = f(m_state + (k2*(stepDt/2.0)), u);
+        const auto k4 = f(m_state + k3*stepDt, u);
+
+        m_state = m_state + (k1 + k2*2.0 + k3*2.0 + k4) * (stepDt/6.0);
+        m_state.theta = std::fmod(m_state.theta, 2.0*PI);
+    }
+};
+
+using StateMsg = gazebo_msgs::ModelState;
+using PoseMsg = geometry_msgs::Pose;
+
+int main(int argc, char **argv)
+{
+    // Init ROS
+    ros::init(argc, argv, "pendulum_sim");
+    ros::NodeHandle nodeHandle;
+
+    // Set up ROS topics for this node
+    constexpr auto cQueueSize = 1;
+    auto statePublisher = nodeHandle.advertise<StateMsg>("pendulum_x", cQueueSize);
+
+    // Initialize a pendulum
+    squirrelRng rng;
+    rng.rand(); // Seed random number generator
+    Pendulum pendulum;
+    // pendulum.m_params.randomize(rng);
+    // pendulum.m_state.randomize(rng);
+    pendulum.m_state.theta = PI;
+    
+    // Set up simulation loop
+    constexpr int updateRate = 100; // Hertz
+    constexpr double stepDt = 1.0 / updateRate;
+    ros::Rate loopRate(100);
+    int i = 0;
+    while(ros::ok())
+    {
+        // Random perturbations
+        if(++i >= 300)
+        {
+            i = 0;
+            pendulum.m_state.perturbate(rng);
+        }
+        // Simulate
+        const auto u = 0.0;
+        pendulum.stepSimulation(stepDt, u);
+
+        // Publish state
+        StateMsg stateUpdate;
+        stateUpdate.pose.orientation.w = pendulum.m_state.theta;
+        stateUpdate.twist.angular.z = pendulum.m_state.dTheta;
+        statePublisher.publish(stateUpdate);
+
+        ros::spinOnce();
+        loopRate.sleep();
+    }
+    return 0;
+}


### PR DESCRIPTION
- Add 4th order Runge-Kutta based simulator
- Add PD controller that kicks in at +-5 deg from the top. This disables the energy pump controller in this range.
- Add matplotlib based lightweight vizualizer.